### PR TITLE
Added support for HTML entities

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -20,7 +20,7 @@ export const getLocalizedElement = (key: string, translations: TranslatedLanguag
 };
 
 export const hasHtmlTags = (value: string): boolean => {
-  const pattern = /<\/?\w+((\s+\w+(\s*=\s*(?:".*?"|'.*?'|[\^'">\s]+))?)+\s*|\s*)\/?>/;
+  const pattern = /(&[^\s]*;|<\/?\w+((\s+\w+(\s*=\s*(?:".*?"|'.*?'|[\^'">\s]+))?)+\s*|\s*)\/?>)/;
   return value.search(pattern) >= 0;
 };
 


### PR DESCRIPTION
Common practise in translations is adding non-breakable spaces (&nbsp;). I would like to have them treated as any other HTML content in translation files.