### PR TITLE
fixed syntax error, use "./Localize" in import instead "./localize"

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -10,7 +10,7 @@ import type { Translations as _Translations } from './locale';
 import type { SingleLanguageTranslation as _SingleLanguageTranslation } from './locale';
 import type { MultipleLanguageTranslation as _MultipleLanguageTranslation } from './locale';
 import type { Translate as _Translate } from './locale';
-import type { LocalizeStateProps as _LocalizeStateProps } from './localize';
+import type { LocalizeStateProps as _LocalizeStateProps } from './Localize';
 
 import type { InitializeAction as _InitializeAction } from './locale';
 import type { AddTranslationAction as _AddTranslationAction } from './locale';


### PR DESCRIPTION
```
Error: node_modules/react-localize-redux/lib/index.js.flow:13
13: import type { LocalizeStateProps as _LocalizeStateProps } from './localize'; 

./localize. Required module not found
```