### PR TITLE
Handle state objects which are Maps

### DIFF
--- a/src/Localize.js
+++ b/src/Localize.js
@@ -12,7 +12,7 @@ export type LocalizeStateProps = {
 };
 
 const mapStateToProps = (slice: ?string): MapStateToProps<LocaleState, {}, LocalizeStateProps> => (state: Object|LocaleState): LocalizeStateProps => {
-  const scopedState: LocaleState = slice ? state[slice] : state;
+  const scopedState: LocaleState = (state instanceof Map ? state.get(slice) : slice && state[slice]) || state;
   return {
     currentLanguage: getActiveLanguage(scopedState).code,
     translate: getTranslate(scopedState)

--- a/tests/Localize.test.js
+++ b/tests/Localize.test.js
@@ -59,4 +59,20 @@ describe('<Localize />', () => {
     expect(wrapper.props().translate).toBeDefined();
     expect(wrapper.props().translate('hi')).toEqual('hello');
   });
+
+  it('should handle a state object which is a Map', () => {
+    const store = mockStore(new Map([
+      ['locale', {
+        ...initialState,
+        translations: {
+          hi: ['hello', '', '']
+        }
+      }]
+    ]));
+    const MockPageComponent = props => (<div>{ translate('hi') }</div>);
+    WrappedComponent = localize(MockPageComponent, 'locale');
+    wrapper = shallow(<WrappedComponent />, { context: { store }});
+    expect(wrapper.props().translate).toBeDefined();
+    expect(wrapper.props().translate('hi')).toEqual('hello');
+  });
 });


### PR DESCRIPTION
This solves the issue in #49 by checking whether the state object is a Map. What this PR does not cover is using Immutable JS without combineReducers, however I think this is a more specialised case and would be best handled as an extension of some kind, or a forked version of the project.

I am new to Flow so you may want to look at annotating the state argument, I had a look at defining a Map containing a LocaleState object however Flow didn't seem to like it. It does not however complain when not defining a Map type, probably because Map is in most respects just an object. I am happy to look further into this.