### PR TITLE
fix Localize undefined active language issue

### DIFF
--- a/src/Localize.js
+++ b/src/Localize.js
@@ -7,15 +7,19 @@ import type { MapStateToProps } from 'react-redux';
 import type { LocaleState, Language, Translate } from './locale';
 
 export type LocalizeStateProps = {
-  currentLanguage: string,
+  currentLanguage?: string,
   translate: Translate
 };
 
 const mapStateToProps = (slice: ?string): MapStateToProps<LocaleState, {}, LocalizeStateProps> => (state: Object|LocaleState): LocalizeStateProps => {
   const scopedState: LocaleState = (state instanceof Map ? state.get(slice) : slice && state[slice]) || state;
+  const language = getActiveLanguage(scopedState);
+  const currentLanguage = language ? language.code : undefined;
+  const translate = getTranslate(scopedState);
+
   return {
-    currentLanguage: getActiveLanguage(scopedState).code,
-    translate: getTranslate(scopedState)
+    currentLanguage,
+    translate
   };
 };
 

--- a/src/locale.js
+++ b/src/locale.js
@@ -278,7 +278,7 @@ export const getActiveLanguage = (state: LocaleState): Language => {
 export const translationsEqualSelector = createSelectorCreator(
   defaultMemoize,
   (cur: Object, prev: Object) => {
-    const isTranslationsData: boolean = !(Array.isArray(cur) || Object.keys(cur).toString() === 'code,active');
+    const isTranslationsData: boolean = cur && !(Array.isArray(cur) || Object.keys(cur).toString() === 'code,active');
 
     // for translations data use a combination of keys and values for comparison
     if (isTranslationsData) {
@@ -306,6 +306,11 @@ export const getTranslationsForActiveLanguage: Selector<LocaleState, void, Trans
   getLanguages,
   getTranslations,
   (activeLanguage, languages, translations) => {
+    // no active language found! return no translations 
+    if (!activeLanguage) {
+      return {};
+    }
+
     const { code: activeLanguageCode } = activeLanguage;
     const activeLanguageIndex = getIndexForLanguageCode(activeLanguageCode, languages);
     return Object.keys(translations).reduce((prev, key) => {

--- a/tests/Localize.test.js
+++ b/tests/Localize.test.js
@@ -76,3 +76,21 @@ describe('<Localize />', () => {
     expect(wrapper.props().translate('hi')).toEqual('hello');
   });
 });
+
+describe('<Localize /> unhappy path', function() {
+  const mockStore = configureStore();
+
+  it('should return currentLanguage = undefined when no active language set', () => {
+    const store = mockStore({
+      locale: {
+        translations: {},
+        languages: []
+      }
+    });
+
+    const MockPageComponent = props => (<div>Hello</div>);
+    const WrappedComponent = localize(MockPageComponent, 'locale');
+    const wrapper = shallow(<WrappedComponent />, { context: { store }});
+    expect(wrapper.props().currentLanguage).not.toBeDefined();
+  });
+});

--- a/tests/locale.test.js
+++ b/tests/locale.test.js
@@ -486,6 +486,14 @@ describe('locale module', () => {
       expect(result).toBe(undefined);
     });
 
+    it('should return undefined if no languages found', () => {
+      const state = {
+        languages: []
+      };
+      const result = getActiveLanguage(state);
+      expect(result).toBe(undefined);
+    });
+
     it('should return activeLanguage with name', () => {
       const state = {
         languages: [{ code: 'en', name: 'English', active: false }, { code: 'fr', name: 'French', active: true }]
@@ -514,6 +522,18 @@ describe('locale module', () => {
         hi: 'hi-fr',
         bye: 'bye-fr'
       });
+    });
+
+    it('should return empty object if no active language found', () => {
+      const state = {
+        languages: [],
+        translations: {
+          hi: ['hi-en', 'hi-fr'],
+          bye: ['bye-en', 'bye-fr']
+        }
+      };
+      const result = getTranslationsForActiveLanguage(state);
+      expect(result).toEqual({});
     });
   });
 


### PR DESCRIPTION
An issue exists where If a user happens to `Localize` a component before active language is set an error would be thrown. 

This fix ensures that the error is not thrown if a user happens to `Localize` a component before they have dispatched `initialize` with their app's languages.