### PR TITLE
add new param to localize to allow user to control how state slice is…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3708,14 +3708,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3724,6 +3716,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4414,6 +4414,12 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "dev": true
+    },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
       "dev": true
     },
     "import-local": {
@@ -7792,15 +7798,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -7841,6 +7838,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "flow-copy-source": "^1.2.1",
     "flow-typed": "^2.1.5",
     "html-webpack-plugin": "^2.24.1",
+    "immutable": "^3.8.2",
     "jest": "^20.0.4",
     "json-loader": "^0.5.4",
     "ncp": "^2.0.0",

--- a/src/Localize.js
+++ b/src/Localize.js
@@ -11,8 +11,13 @@ export type LocalizeStateProps = {
   translate: Translate
 };
 
-const mapStateToProps = (slice: ?string): MapStateToProps<LocaleState, {}, LocalizeStateProps> => (state: Object|LocaleState): LocalizeStateProps => {
-  const scopedState: LocaleState = (state instanceof Map ? state.get(slice) : slice && state[slice]) || state;
+export type GetSliceStateFn = (state: Object|LocaleState) => LocaleState;
+
+const mapStateToProps = (slice: ?string, getStateSlice: ?GetSliceStateFn): MapStateToProps<LocaleState, {}, LocalizeStateProps> => (state: Object|LocaleState): LocalizeStateProps => {
+  const scopedState: LocaleState = getStateSlice
+    ? getStateSlice(state)
+    : (slice && state[slice]) || state;
+
   const language = getActiveLanguage(scopedState);
   const currentLanguage = language ? language.code : undefined;
   const translate = getTranslate(scopedState);
@@ -23,4 +28,4 @@ const mapStateToProps = (slice: ?string): MapStateToProps<LocaleState, {}, Local
   };
 };
 
-export const localize = (Component: ComponentType<any>, slice: ?string = null) => connect(mapStateToProps(slice))(Component);
+export const localize = (Component: ComponentType<any>, slice: ?string = null, getStateSlice: ?GetSliceStateFn = null) => connect(mapStateToProps(slice, getStateSlice))(Component);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -111,6 +111,8 @@ export type Action = BaseAction<
   & SetLanguagesPayload
 >;
 
+export type GetSliceStateFn = (state: Object|LocaleState) => LocaleState;
+
 export type ActionLanguageCodes = Action & { languageCodes: string[] };
 
 export function localeReducer(state: LocaleState, action: Action): LocaleState;
@@ -135,4 +137,4 @@ export function getActiveLanguage(state: LocaleState): Language;
 
 export function getTranslate(state: LocaleState): Translate;
 
-export function localize(Component: Component<any>, slice?: string): (state: LocaleState) => ComponentClass<LocalizeProps>;
+export function localize(Component: Component<any>, slice?: string, getStateSlice?: GetSliceStateFn): (state: Object|LocaleState) => ComponentClass<LocalizeProps>;

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -11,6 +11,7 @@ import type { SingleLanguageTranslation as _SingleLanguageTranslation } from './
 import type { MultipleLanguageTranslation as _MultipleLanguageTranslation } from './locale';
 import type { Translate as _Translate } from './locale';
 import type { LocalizeStateProps as _LocalizeStateProps } from './Localize';
+import type { GetSliceStateFn as _GetSliceStateFn } from './Localize';
 
 import type { InitializeAction as _InitializeAction } from './locale';
 import type { AddTranslationAction as _AddTranslationAction } from './locale';
@@ -28,6 +29,7 @@ export type SingleLanguageTranslation = _SingleLanguageTranslation;
 export type MultipleLanguageTranslation = _MultipleLanguageTranslation;
 export type Translate = _Translate;
 export type LocalizeStateProps = _LocalizeStateProps;
+export type GetSliceStateFn = _GetSliceStateFn;
 
 export type InitializeAction = _InitializeAction;
 export type AddTranslationAction = _AddTranslationAction;
@@ -82,5 +84,5 @@ declare export function getTranslate(
 ): Translate;
 
 declare export function localize(
-  Component: ComponentType<any>, slice?: string
-): (state: LocaleState) => ComponentType<LocalizeStateProps>;
+  Component: ComponentType<any>, slice?: string, getStateSlice?: GetSliceStateFn
+): (state: Object|LocaleState) => ComponentType<LocalizeStateProps>;

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,7 +9,7 @@ export const getLocalizedElement = (key: string, translations: TranslatedLanguag
       options.missingTranslationCallback(key, activeLanguage.code);
     }
     return options.showMissingTranslationMsg  
-      ? templater(options.missingTranslationMsg, { key, code: activeLanguage.code })
+      ? templater(options.missingTranslationMsg || '', { key, code: activeLanguage.code })
       : '';
   };
   const localizedString = translations[key] || onMissingTranslation();

--- a/tests/Localize.test.js
+++ b/tests/Localize.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Map } from 'immutable';
 import Enzyme, { shallow, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import configureStore from 'redux-mock-store';
@@ -60,17 +61,18 @@ describe('<Localize />', () => {
     expect(wrapper.props().translate('hi')).toEqual('hello');
   });
 
-  it('should handle a state object which is a Map', () => {
-    const store = mockStore(new Map([
-      ['locale', {
+  it('should allow for passing a custom function to return state slice', () => {
+    const store = mockStore(Map({
+      locale: {
         ...initialState,
         translations: {
           hi: ['hello', '', '']
         }
-      }]
-    ]));
+      }
+    }));
     const MockPageComponent = props => (<div>{ translate('hi') }</div>);
-    WrappedComponent = localize(MockPageComponent, 'locale');
+    const getStateSlice = (state) => state.toJS()['locale'];
+    WrappedComponent = localize(MockPageComponent, 'locale', getStateSlice);
     wrapper = shallow(<WrappedComponent />, { context: { store }});
     expect(wrapper.props().translate).toBeDefined();
     expect(wrapper.props().translate('hi')).toEqual('hello');


### PR DESCRIPTION
Currently this is specific to handling apps that are using ImmutableJS, but has no dependency on ImmutableJS. Allows user to pass their own `getStateSlice` function to `localize` to control how state slice is retrieved. 