### PR TITLE
Add ignoreTranslateChildren to docs.

### DIFF
--- a/docs/api/action-creators.md
+++ b/docs/api/action-creators.md
@@ -19,6 +19,7 @@ showMissingTranslationMsg | boolean | true | Controls whether missing translatio
 missingTranslationMsg | string | Missing translation key ${key} for language ${code} | A message that will be rendered in place of missing translations
 missingTranslationCallback | function | undefined | A function that will be called when attempting to get an undefined translation. See [Handle missing translations](/features/#handle-missing-translations) for details.
 translationTransform | function | undefined | A transformation function that will be applied to translation data. See [Custom data format](/formatting-translation-data#custom-data-format) for details.
+ignoreTranslateChildren | boolean | false | A flag that determines whether or not to add the children of `<Translate>` to the default language. This can be useful for defining default values in tests without adding them to translations.
 
 <div class="admonition error">
   <p class="first admonition-title">Deprecated</p>


### PR DESCRIPTION
Thank you for this library.

I noticed that this part is missing. I'm not sure if it is intentional or not, but here is a simple PR - feel free to close if it is intentional :)

In case you are wondering how I came across this 'hidden' feature:

I have requirements for both:
* an explicitly-defined default language and translations (fetched from external API resource)
* placeholder children for `Translate` for use in a test environment.

Therefore I wanted placeholders that I could query during tests without loading the actual full set of translations, but during normal usage I did not want these placeholders added to the fetched translations set.