### PR TITLE
[v3] - Minor change for TS types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-import { ReactElement, ReactNode, Component as ReactComponent } from 'react';
+import { ReactElement, ReactNode, Component as ReactComponent, ComponentType } from 'react';
 import { Store } from 'redux';
 import { ComponentClass, Component } from 'react-redux';
 
@@ -41,6 +41,7 @@ export interface InitializeOptions {
   renderInnerHtml?: boolean;
   onMissingTranslation?: onMissingTranslationFunction;
   defaultLanguage?: string;
+  ignoreTranslateChildren?: boolean;
 }
 
 export interface TranslateOptions {
@@ -203,8 +204,8 @@ export function getActiveLanguage(state: LocalizeState): Language;
 export function getTranslate(state: LocalizeState): TranslateFunction;
 
 export function withLocalize<Props extends {}>(
-  WrappedComponent: ReactComponent<Props>
-): ReactComponent<Props & LocalizeContextProps>;
+  WrappedComponent: ComponentType<Props>
+): ComponentType<Props & LocalizeContextProps>;
 
 export function TranslateChildFunction(
   context: LocalizeContextProps


### PR DESCRIPTION
### Summary
I was having some conflict when using `withLocalize` in a TS project. I think it's due to the fact that `withLocalize` is typed to wrap and return `React.Component`, as opposed to `React.ComponentType`.

### Changes
1. Changed `withLocalize` to wrap and return `React.ComponentType<P>`
2. Added the `ignoreTranslateChildren` option to `initialize`, which I believe should be in there.

### Reference
[As you can see here](https://github.com/piotrwitek/react-redux-typescript-guide#reactcomponentp-s), `React.Component` refers to a stateful class component, whereas this function should be compatible with either stateful/stateless function components.