### PR TITLE
[v3] - Add default translate if id prop changes.

### DIFF
--- a/src/Translate.js
+++ b/src/Translate.js
@@ -27,7 +27,8 @@ export type TranslateProps = {
 };
 
 type TranslateState = {
-  hasAddedDefaultTranslation: boolean
+  hasAddedDefaultTranslation: boolean,
+  lastKnownId: string
 };
 
 export type TranslateChildFunction = (context: LocalizeContextProps) => any;
@@ -39,6 +40,17 @@ export class Translate extends React.Component<TranslateProps, TranslateState> {
     super(props);
 
     this.state = {
+      hasAddedDefaultTranslation: false,
+      lastKnownId: ''
+    };
+  }
+
+  static getDerivedStateFromProps(props, prevState) {
+    if (prevState.lastKnownId === props.id) return {
+      hasAddedDefaultTranslation: true
+    };
+    return {
+      lastKnownId: props.id,
       hasAddedDefaultTranslation: false
     };
   }

--- a/tests/Translate.test.js
+++ b/tests/Translate.test.js
@@ -122,6 +122,27 @@ describe('<Translate />', () => {
     );
   });
 
+  it('should add <Translate>\'s children to translations when id changes', () => {
+    const Translate = getTranslateWithContext();
+    const Parent = ({ condition }) => (condition ? <Translate id="hello">
+          Hello
+        </Translate> : <Translate id="world">World</Translate>);
+
+    const wrapper = mount(<Parent condition />);
+
+    expect(defaultContext.addTranslationForLanguage).toHaveBeenLastCalledWith(
+      {"hello": "Hello"},
+      "en"
+    );
+
+    wrapper.setProps({ condition: false });
+
+    expect(defaultContext.addTranslationForLanguage).toHaveBeenLastCalledWith(
+      {"world": "World"},
+      "en"
+    );
+  });
+
   it('should add <Translate>\'s children to translations under options.defaultLanguage for id', () => {
     const Translate = getTranslateWithContext();
     const wrapper = mount(<Translate id="hello" options={{language: 'fr'}}>Hey</Translate>);


### PR DESCRIPTION
For https://github.com/ryandrewjohnson/react-localize-redux/issues/67#issuecomment-394076318

### Summary
When two `Translate` components are declared in the same position in the tree (e.g. using a ternary to  switch between a 'Submit' and 'Please Select' button), the `addDefaultTranslation` is not called when the ternary conditions changes.

### Cause
`addDefaultTranslation` is blocked if the state flag `hasAddedDefaultTranslation` is true. This flag is set once per component lifecycle, so changes to the `id` prop (which should cause it to re-run) always hit a `hasAddedDefaultTranslation: true` condition. This is because the component re-renders without going through the entire lifecycle.

### Changes
It is not possible to alter where `addDefaultTranslation` is called, since it requires the `context` argument from the Context Consumer. Therefore it is necessary to reset the `hasAddedDefaultTranslation` flag at the appropriate time:
* if the `id` prop changes and;
* *before* the render function is called

I have used `static getDerivedStateFromProps` for this, as this [runs before every render](https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops). Because we cannot access `this` within the static method, there is a need to store the `id` prop in state to allow us to make the comparison (I believe this is an accepted pattern, will try and find a discussion on it - [Edit - here](https://github.com/reactjs/reactjs.org/issues/721#issuecomment-377219370)).

### Notes
This only responds to the last time the `id` prop changes. So if you continually re-render between 2 or more different `id`s, the `addDefaultTranslation` function **will** run redundantly:
1. Mount component with `props.id = 1` (runs since this is a "new" `id`)
2. Change `props.id = 2` (runs since 2 !== 1)
3. Change back to `props.id = 1` (runs again since 1 !== 2)

I'm guessing Step 3 will actually terminate earlier than Step 1, since after Step 1 there is no missing translation for `id: 1`?

[Edit] - there is a way to avoid this, which is to keep a list of all `id`s that the component has ever rendered with in state, instead of just the last one. However this doesn't feel right to me somehow.