### PR TITLE
Ensure that addDefaultTranslation gets called

### DIFF
--- a/src/Translate.js
+++ b/src/Translate.js
@@ -9,7 +9,7 @@ import {
   getActiveLanguage,
   getTranslationsForActiveLanguage
 } from './localize';
-import { storeDidChange } from './utils';
+import { get, storeDidChange } from './utils';
 import { LocalizeContext, type LocalizeContextProps } from './LocalizeContext';
 import { withLocalize } from './withLocalize';
 import type {
@@ -39,7 +39,18 @@ class WrappedTranslate extends React.Component<TranslateWithContextProps> {
   }
 
   componentDidUpdate(prevProps: TranslateWithContextProps) {
-    if (this.props.id && prevProps.id !== this.props.id) {
+    const idChanged = this.props.id && prevProps.id !== this.props.id;
+
+    const noDefaultLanguage =
+      !get(prevProps, 'context.defaultLanguage') &&
+      !get(prevProps, 'options.language');
+    const incomingLanguage =
+      get(this.props, 'context.defaultLanguage') ||
+      get(this.props, 'options.language');
+
+    const defaultLanguageSet = noDefaultLanguage && incomingLanguage;
+
+    if (idChanged || defaultLanguageSet) {
       this.addDefaultTranslation();
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -185,6 +185,13 @@ export const getSingleToMultilanguageTranslation = (
   return singleLanguageTranslations;
 };
 
+export const get = (obj: Object, path: string, defaultValue: any = undefined) => {
+  const pathArr = path.split('.').filter(Boolean);
+  return pathArr.reduce((ret, key) => {
+    return ret && ret[key] ? ret[key] : defaultValue;
+  }, obj);
+};
+
 // Thanks react-redux for utility function
 // https://github.com/reactjs/react-redux/blob/master/src/utils/warning.js
 export const warning = (message: string) => {

--- a/tests/Translate.test.js
+++ b/tests/Translate.test.js
@@ -40,7 +40,7 @@ describe('<Translate />', () => {
       translate: getTranslate(localizeState),
       languages: getLanguages(localizeState),
       defaultLanguage:
-        state.options.defaultLanguage || getLanguages(localizeState)[0].code,
+        state.options.defaultLanguage || (getLanguages(localizeState)[0] && getLanguages(localizeState)[0].code),
       activeLanguage: getActiveLanguage(localizeState),
       initialize: jest.fn(),
       addTranslation: jest.fn(),
@@ -152,6 +152,22 @@ describe('<Translate />', () => {
 
     expect(defaultContext.addTranslationForLanguage).toHaveBeenLastCalledWith(
       { world: 'World' },
+      'en'
+    );
+  });
+
+  it("should add <Translate>'s children to translations when default language is set", () => {
+    const Translate = getTranslateWithContext({...initialState, languages: [] });
+    const wrapper = mount(
+      <Translate id='no_translation'>
+        Default Translation
+      </Translate>
+    );
+
+    wrapper.setProps({options: {language: 'en'}});
+
+    expect(defaultContext.addTranslationForLanguage).toHaveBeenLastCalledWith(
+      { 'no_translation': 'Default Translation' },
       'en'
     );
   });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -168,4 +168,24 @@ describe('locale utils', () => {
       expect(() => utils.validateOptions(options)).toThrow();
     });
   });
+
+  describe('get', () => {
+    
+    const obj = { a: { b: { c: 'd' } } };
+    
+    it('gets value at path', () => {
+      const path = 'a.b.c';
+      expect(utils.get(obj, path)).toBe('d');
+    });
+
+    it('returns passed default value', () => {
+      const path = 'foo';
+      expect(utils.get(obj, path, 'default')).toBe('default');
+    });
+
+    it('falls back to undefined', () => {
+      const path = 'foo';
+      expect(utils.get(obj, path)).toBeUndefined();
+    })
+  });
 });


### PR DESCRIPTION
For #97 

This change implements a fix based on the solution described in the linked issue.

## Changes

#### `utils.get`
I added a helper to access values nested in objects. This is just to avoid verbose checks like:
```js
if (obj && obj.a && obj.a.b) return obj.a.b.c

// instead

const val = get(obj, 'a.b.c', 'fallback Value')
```
Inspired by `lodash.get`, but probably much simpler.

#### `Translate.js`
I added some logic to check if the defaultLanguage has gone from undefined to something. It looks a bit verbose but there is a need to check both `props.context` and `props.options` I think. @ryandrewjohnson I don't know if there is a need to address the case where the language changes from one language to another?

#### `Translate.test.js`
In `getTranslateWithContext()`, I amended the default language to better reflect how this value is arrived in real use.

As far as I can tell, in real use, `defaultLanguage` may start off as undefined, before `initialize()` has completed. It is impossible to recreate this in `getTranslateWithContext()` because it has a default to ensure that `defaultLanguage` is always defined.

To simulate real use, you can explicitly pass an empty language option array to the initialState in `getTranslateWithContext(initialState)`. This then throws because the default I mentioned above is accessing `languages[0].code`. So i just added a check to see if there is an element at `languages[0]`, otherwise return `undefined`.

```js
// before
state.options.defaultLanguage || getLanguages(localizeState)[0].code

// after
state.options.defaultLanguage || (getLanguages(localizeState)[0] && getLanguages(localizeState)[0].code)
```
This matches how the default language is determined in `LocalizeContext`:
```js
// in getContextPropsFromState()

const defaultLanguage = options.defaultLanguage || (languages[0] && languages[0].code)

// Note the check for languages[0]
```
To simulate the defaultLanguage changing from undefined to something, in the test case I created `Translate` with an empty languages array, then explicitly set the `options` prop on Translate to contain a language. Then we can assert that `addTranslationForLanguage()` was called.