### PR TITLE
Grab first available language as default if one isn't set, localize missing translation fallbacks

### DIFF
--- a/src/localize.js
+++ b/src/localize.js
@@ -473,19 +473,30 @@ export const getTranslate: Selector<
             ? getTranslationsForLanguage(defaultLanguage)
             : {};
 
-
-
       const languageCode =
         overrideLanguage !== undefined
           ? overrideLanguage
           : activeLanguage && activeLanguage.code;
 
       const onMissingTranslation = (translationId: string) => {
+
+        // Overwrite the param translations with the defaultTranslations to use as a
+        // fallback when a translation is missing. Additionally, if we're already in
+        // our onMissingTranslation function, we want to avoid trying to retriggering
+        // onMissingTranslation when passing it in or we'll throw ourselves into a loop.
+        // Revert to default at this point to throw a missing key error
+
+        const missingSharedParams = Object.assign(sharedParams, {
+          translations: defaultTranslations,
+          onMissingTranslation: defaultTranslateOptions.onMissingTranslation
+        });
+
         return mergedOptions.onMissingTranslation({
           translationId,
           languageCode,
-          defaultTranslation: defaultTranslations[translationId]
+          defaultTranslation: getLocalizedElement({ translationId: translationId, ...missingSharedParams })
         });
+
       };
 
       const mergedOptions = { ...defaultOptions, ...translateOptions };

--- a/src/localize.js
+++ b/src/localize.js
@@ -103,7 +103,7 @@ export type MultipleLanguageTranslation = {
 type MissingTranslationOptions = {
   translationId: string,
   languageCode: string,
-  defaultTranslation: string
+  defaultTranslation: onMissingTranslationFunction
 };
 
 export type onMissingTranslationFunction = (
@@ -293,7 +293,7 @@ export const defaultTranslateOptions: InitializeOptions = {
   renderToStaticMarkup: false,
   renderInnerHtml: false,
   ignoreTranslateChildren: false,
-  defaultLanguage: null,
+  defaultLanguage: '',
   onMissingTranslation: ({ translationId, languageCode }) =>
     'Missing translationId: ${ translationId } for language: ${ languageCode }'
 };
@@ -370,13 +370,13 @@ export const getOptions = (state: LocalizeState): InitializeOptions => {
   // If there isn't a default language, grab the first languages from the
   // available languages as default
 
-  if ( !options.defaultLanguage ) {
+  if (!options.defaultLanguage) {
     languages = getLanguages(state) || [];
-    options.defaultLanguage = languages[0] ? languages[0].code : null;
+    options.defaultLanguage = languages[0] ? languages[0].code : '';
   }
 
   return options;
-}
+};
 
 export const getActiveLanguage = (state: LocalizeState): Language => {
   const languages = getLanguages(state);
@@ -466,8 +466,7 @@ export const getTranslate: Selector<
           : translationsForActiveLanguage;
 
       const defaultTranslations =
-        activeLanguage &&
-        activeLanguage.code === defaultLanguage
+        activeLanguage && activeLanguage.code === defaultLanguage
           ? translationsForActiveLanguage
           : defaultLanguage !== undefined
             ? getTranslationsForLanguage(defaultLanguage)
@@ -479,7 +478,6 @@ export const getTranslate: Selector<
           : activeLanguage && activeLanguage.code;
 
       const onMissingTranslation = (translationId: string) => {
-
         // Overwrite the param translations with the defaultTranslations to use as a
         // fallback when a translation is missing. Additionally, if we're already in
         // our onMissingTranslation function, we want to avoid trying to retriggering
@@ -494,9 +492,11 @@ export const getTranslate: Selector<
         return mergedOptions.onMissingTranslation({
           translationId,
           languageCode,
-          defaultTranslation: getLocalizedElement({ translationId: translationId, ...missingSharedParams })
+          defaultTranslation: getLocalizedElement({
+            translationId: translationId,
+            ...missingSharedParams
+          })
         });
-
       };
 
       const mergedOptions = { ...defaultOptions, ...translateOptions };

--- a/src/localize.js
+++ b/src/localize.js
@@ -56,6 +56,7 @@ export type TranslateOptions = {
   language?: string,
   renderInnerHtml?: boolean,
   onMissingTranslation?: onMissingTranslationFunction,
+  defaultLanguage?: string,
   ignoreTranslateChildren?: boolean
 };
 
@@ -292,6 +293,7 @@ export const defaultTranslateOptions: InitializeOptions = {
   renderToStaticMarkup: false,
   renderInnerHtml: false,
   ignoreTranslateChildren: false,
+  defaultLanguage: null,
   onMissingTranslation: ({ translationId, languageCode }) =>
     'Missing translationId: ${ translationId } for language: ${ languageCode }'
 };
@@ -361,8 +363,20 @@ export const getTranslations = (state: LocalizeState): Translations => {
 export const getLanguages = (state: LocalizeState): Language[] =>
   state.languages;
 
-export const getOptions = (state: LocalizeState): InitializeOptions =>
-  state.options;
+export const getOptions = (state: LocalizeState): InitializeOptions => {
+  const options = Object.assign({}, state.options);
+  let languages;
+
+  // If there isn't a default language, grab the first languages from the
+  // available languages as default
+
+  if ( !options.defaultLanguage ) {
+    languages = getLanguages(state) || [];
+    options.defaultLanguage = languages[0] ? languages[0].code : null;
+  }
+
+  return options;
+}
 
 export const getActiveLanguage = (state: LocalizeState): Language => {
   const languages = getLanguages(state);
@@ -453,11 +467,13 @@ export const getTranslate: Selector<
 
       const defaultTranslations =
         activeLanguage &&
-        activeLanguage.code === initializeOptions.defaultLanguage
+        activeLanguage.code === defaultLanguage
           ? translationsForActiveLanguage
-          : initializeOptions.defaultLanguage !== undefined
-            ? getTranslationsForLanguage(initializeOptions.defaultLanguage)
+          : defaultLanguage !== undefined
+            ? getTranslationsForLanguage(defaultLanguage)
             : {};
+
+
 
       const languageCode =
         overrideLanguage !== undefined

--- a/src/utils.js
+++ b/src/utils.js
@@ -150,7 +150,7 @@ export const validateOptions = (
     typeof options.renderToStaticMarkup !== 'function'
   ) {
     throw new Error(`
-      react-localize-redux: initialize option renderToStaticMarkup is invalid. 
+      react-localize-redux: initialize option renderToStaticMarkup is invalid.
       Please see https://ryandrewjohnson.github.io/react-localize-docs/#initialize.
     `);
   }

--- a/tests/localize.test.js
+++ b/tests/localize.test.js
@@ -658,7 +658,8 @@ describe('localize', () => {
           bye: ['bye-en', 'bye-fr'],
           yo: ['yo ${ name }', 'yo-fr ${ name }'],
           foo: ['foo ${ bar }', 'foo-fr ${ bar }'],
-          html: ['<b>hi-en</b>', '<b>hi-fr</b>']
+          html: ['<b>hi-en</b>', '<b>hi-fr</b>'],
+          money_no_translation: ['save $${ amount }']
         },
         options: defaultTranslateOptions
       };
@@ -747,6 +748,19 @@ describe('localize', () => {
       expect(result).toEqual(
         'Missing translationId: nothinghere for language: fr'
       );
+    });
+
+    it('should insert default when missing translation with USD hard coded into translation', () => {
+      state.options.onMissingTranslation = ({ defaultTranslation }) => defaultTranslation;
+      // state.options.defaultLanguage = "en";
+      const translate = getTranslate(state);
+      const result = translate(['money_no_translation'], { amount: 100 });
+      const results = ['save-fr $100'];
+
+      Object.keys(result).map((key, index) => {
+        const value = result[key];
+        expect(value).toBe(results[index]);
+      });
     });
 
     it('should return value from onMissingTranslation option override', () => {

--- a/tests/localize.test.js
+++ b/tests/localize.test.js
@@ -3,6 +3,7 @@ import Adapter from 'enzyme-adapter-react-16';
 import {
   languages,
   translations,
+  getOptions,
   getActiveLanguage,
   getTranslationsForActiveLanguage,
   getTranslationsForSpecificLanguage,
@@ -750,17 +751,17 @@ describe('localize', () => {
       );
     });
 
-    it('should insert default when missing translation with USD hard coded into translation', () => {
-      state.options.onMissingTranslation = ({ defaultTranslation }) => defaultTranslation;
-      // state.options.defaultLanguage = "en";
-      const translate = getTranslate(state);
-      const result = translate(['money_no_translation'], { amount: 100 });
-      const results = ['save-fr $100'];
+    it('should set first language available as default when no default is set', () => {
+      const options = getOptions(state);
+      expect(options.defaultLanguage).toBe(state.languages[0].code);
+    });
 
-      Object.keys(result).map((key, index) => {
-        const value = result[key];
-        expect(value).toBe(results[index]);
-      });
+    it('should return value using default language when missing a translation with USD hard coded into translation', () => {
+      state.options.onMissingTranslation = ({ defaultTranslation }) => defaultTranslation;
+      const key = 'money_no_translation';
+      const translate = getTranslate(state);
+      const result = translate([key], { amount: 100 });
+      expect(result[key]).toBe('save $100')
     });
 
     it('should return value from onMissingTranslation option override', () => {


### PR DESCRIPTION
## Overview
Fix for #101 

Two issues:
 - The application doesn't take the first item as a default language when a `defaultLanguage` isn't present
 - When falling back to the default translation using `onMissingTranslation`, the translation doesn't run through `getLocalizedElement` which prevents any variables from getting parsed

## Solution

### defaultLanguage
The `getOptions` function now falls back to the first available language if a `defaultLanguage` isn't provided.

### onMissingTranslation
When onMissingTranslation fires, it gets passed into `getLocalizedElement` which allows any variables to get parsed out.

## Notes
### Flow
Having issues debugging the flow issues, there are 2 that are from my changes, but a few that were there prior to this fix. Would appreciate some feedback here.