### PR TITLE
Import ComponentClass and Component

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,7 +5,7 @@ import {
   ComponentType
 } from 'react';
 import { Store } from 'redux';
-import { ComponentClass, Component } from 'react-redux';
+import { ComponentClass, Component } from 'react';
 
 export as namespace ReactLocalizeRedux;
 


### PR DESCRIPTION
Both ComponentClass and Component should be imported from `react`. `react-redux` doesn't contain those two.
