### PR TITLE
Allow passing of custom getState function

### DIFF
--- a/src/LocalizeProvider.js
+++ b/src/LocalizeProvider.js
@@ -22,6 +22,7 @@ type LocalizeProviderState = {
 
 export type LocalizeProviderProps = {
   store?: Store<any, any>,
+  getState?: Function,
   children: any
 };
 
@@ -68,9 +69,10 @@ export class LocalizeProvider extends Component<
     if (!this.props.store) {
       return;
     }
+    const getState = this.props.getState || (state => state.localize);
 
-    const prevLocalizeState = prevState && prevState.localize;
-    const curLocalizeState = this.props.store.getState().localize;
+    const prevLocalizeState = prevState && getState(prevState);
+    const curLocalizeState = getState(this.props.store.getState());
 
     const prevActiveLanguage =
       prevState && getActiveLanguage(prevLocalizeState);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -82,6 +82,7 @@ export interface LocalizeContextProps {
 
 export interface LocalizeProviderProps {
   store?: Store<any>;
+  getState?: (state: any) => LocalizeState;
   children: any;
 }
 

--- a/tests/LocalizeProvider.test.js
+++ b/tests/LocalizeProvider.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Enzyme, { shallow, mount } from 'enzyme';
 import { createStore, combineReducers } from 'redux';
 import Adapter from 'enzyme-adapter-react-16';
+import { Map } from 'immutable'
 import { LocalizeProvider } from '../src/LocalizeProvider';
 import { localizeReducer } from '../src/localize';
 import { getTranslate, getLanguages, initialize } from '../src';
@@ -30,6 +31,10 @@ describe('<LocalizeProvider />', () => {
       localize: localizeReducer
     }));
   };
+  const getImmutableStore = () => {
+    const reducer = (s, a) => Map({localize: localizeReducer(s, a)});
+    return createStore(reducer, Map({localize: initialState}));
+  }
 
   it('should set default values for localize state', () => {
     const wrapper = shallow(
@@ -66,6 +71,17 @@ describe('<LocalizeProvider />', () => {
       shallow(
         <LocalizeProvider store={store}>
           <div>Hello</div>
+        </LocalizeProvider>
+      )
+    }).not.toThrow();
+  });
+
+  it('should allow passing a custom function to access state', () => {
+    const store = getImmutableStore();
+    expect(() => {
+      shallow(
+        <LocalizeProvider store={store} getState={state => state.get('localize')}>
+        <div>Hello</div>
         </LocalizeProvider>
       )
     }).not.toThrow();


### PR DESCRIPTION
For #82.

## Changes
Added an optional `getState()` prop to `LocalizeProvider`. If passed, it will be used to access `state.localize` instead of the default dot notation.

Note that the localize state itself is always a plain JS object, so there should be no need to consider any changes deeper than this.