### PR TITLE
Handle falsy values in data.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -88,7 +88,8 @@ export const templater = (
         const regex = new RegExp(pattern, 'gmi');
         if (regex.test(templatePortion)) matched = data[prop];
       }
-      return matched || templatePortion;
+      if (typeof matched === 'undefined') return templatePortion;
+      return matched;
     });
 
   // if there is a React element, return as array

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -90,7 +90,15 @@ describe('locale utils', () => {
       const after = ['Hello this is a ', <Comp /> , ' translation'];
       const result = utils.templater(before, data);
       expect(result).toEqual(after);
-    })
+    });
+
+    it('should handle falsy data values (except undefined)', () => {
+      const data = { zero: 0, empty: '' };
+      const before = 'Number ${zero}, empty ${empty}';
+      const after = 'Number 0, empty ';
+      const result = utils.templater(before, data);
+      expect(result).toEqual(after);
+    });
   });
   
   describe('getIndexForLanguageCode', () => {


### PR DESCRIPTION
For #116.

## Problem
The `templater` is supposed to replace the placeholder parts of the translation string with the interpolated data. It will skip over the parts of the translation string that are not placeholders. It does this by setting a `matched` variable with the interpolated data, or leaving it undefined if there is no interpolation needed. Currently it fails to detect if the interpolated data is falsy (`0`, `""`), and thus returns the literal string in the translation.

## Changes
I have made it detect any data value except undefined, so you can pass `0` or an empty string in the data and have it render correctly.