### PR TITLE
Fix too eager templater reg exp

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -72,7 +72,7 @@ export const templater = (
 
   // ${**}
   // brackets to include it in the result of .split()
-  const genericPlaceholderPattern = '(\\${\\s*[^\\s]+\\s*})';
+  const genericPlaceholderPattern = '(\\${\\s*[^\\s}]+\\s*})';
 
   // split: from 'Hey ${name}' -> ['Hey', '${name}']
   // filter: clean empty strings

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -77,6 +77,14 @@ describe('locale utils', () => {
       expect(result).toEqual(after);
     });
 
+    it('should replace all variables in the string even when variable are stucked together', () => {
+      const data = { name: 'Ryan', type: 'Air' };
+      const before = 'Hi my airline company is ${name}${type}';
+      const after = 'Hi my airline company is RyanAir';
+      const result = utils.templater(before, data);
+      expect(result).toEqual(after);
+    });
+
     it('should not modify string if no data param is provided', () => {
       const before = 'Hi my name is ${ name } and I live in ${ country }';
       const result = utils.templater(before);


### PR DESCRIPTION
This pull request is fixing a simple bug that prevent the option to have two or more patterns without any spaces between them without having to add spaces inside the curly braces:

examples of pattern this PR solves:
```js
"${num}/${total}"
"${value}${index}"
"${filename}.${ext}"
...
```

In the current code, it doesn't works because the `genericPlaceholderPattern` is too eager and split the patterns as one element (eg: `["${num}/${total}"]` instead of `["${num}", "/", "${total}"]`) then it changes the first value so we get only the equivalent of `${num}` if we keep my last example.

And indeed, they all can be solved like this:

```js
"${ num }/${ total }"
"${ value }${ index }"
"${ filename }.${ ext }"
...
```

but let's not limiting the options of your users ? 😉 

thanks in advance!