### PR TITLE
Fixed issue with static methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
   "dependencies": {
     "create-react-context": "^0.2.2",
     "flat": "^2.0.1",
+    "hoist-non-react-statics": "^3.0.1",
     "prop-types": "^15.6.1",
     "reselect": "^3.0.1"
   }

--- a/src/withLocalize.js
+++ b/src/withLocalize.js
@@ -1,5 +1,6 @@
 import React, { Component, type ComponentType } from 'react';
 import { LocalizeContext, type LocalizeContextProps } from './LocalizeContext';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 
 export function withLocalize<Props: {}>(
   WrappedComponent: ComponentType<Props>
@@ -11,6 +12,9 @@ export function withLocalize<Props: {}>(
       </LocalizeContext.Consumer>
     );
   };
+
+  // Automatically copy over static variables
+  hoistNonReactStatics(LocalizedComponent, WrappedComponent);
 
   return LocalizedComponent;
 }


### PR DESCRIPTION
Fixed the following [issue](https://github.com/ryandrewjohnson/react-localize-redux/issues/122) by using [hoist-non-react-statics](https://github.com/mridgway/hoist-non-react-statics) to automatically copy all non-React static methods. For more information se [Reacts official documentation](https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over)