### PR TITLE
add initialize prop to LocaizeProvider to support SSR

### DIFF
--- a/src/LocalizeProvider.js
+++ b/src/LocalizeProvider.js
@@ -7,7 +7,9 @@ import {
   getOptions,
   getTranslationsForActiveLanguage,
   type LocalizeState,
-  type Action
+  type Action,
+  INITIALIZE,
+  InitializePayload
 } from './localize';
 import {
   LocalizeContext,
@@ -23,6 +25,7 @@ type LocalizeProviderState = {
 export type LocalizeProviderProps = {
   store?: Store<any, any>,
   getState?: Function,
+  initialize?: InitializePayload,
   children: any
 };
 
@@ -43,8 +46,16 @@ export class LocalizeProvider extends Component<
 
     this.getContextPropsSelector = getContextPropsFromState(dispatch);
 
+    const initialState =
+      this.props.initialize !== undefined
+        ? localizeReducer(undefined, {
+            type: INITIALIZE,
+            payload: this.props.initialize
+          })
+        : localizeReducer(undefined, ({}: any));
+
     this.state = {
-      localize: localizeReducer(undefined, ({}: any))
+      localize: initialState
     };
   }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,7 +4,6 @@ import {
   Component as ReactComponent,
   ComponentType
 } from 'react';
-import { Store } from 'redux';
 
 export as namespace ReactLocalizeRedux;
 
@@ -81,8 +80,9 @@ export interface LocalizeContextProps {
 }
 
 export interface LocalizeProviderProps {
-  store?: Store<any>;
+  store?: any;
   getState?: (state: any) => LocalizeState;
+  initialize?: InitializePayload;
   children: any;
 }
 

--- a/src/localize.js
+++ b/src/localize.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react';
-import { combineReducers } from 'redux';
 import { flatten } from 'flat';
 import {
   createSelector,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react';
 import { type Store } from 'redux';
-import { flatten } from 'flat';
 import {
   defaultTranslateOptions,
   type MultipleLanguageTranslation


### PR DESCRIPTION
Proposed fix for #125 and #103 both related to server side rendering.

#### Issue:

The library currently doesn't work with server side rendering, as the initial context for LocalizeProvider has no values for `languages`, or `translations` until the `initialize` action is called. 

Since no the state changes triggered by the `initialize` action will be tracked on the server this results in the empty context. This causes issues when the server attempts to render components with translations, and results in errors being thrown because of missing languages, and translation data.

#### Solution:
Allow for passing `initialize` payload as a prop to `LocalizeProvider`. If using server side rendering this would be the required way to `initialize`, and would need to be done on the server and the client.

**Example:**
```jsx
// from server
const result = ReactDOMServer.renderToString(
      <LocalizeProvider initialize={{
        languages: [
          { name: "English", code: "en" },
          { name: "French", code: "fr" }
        ],
        translation: {
          hello: ['hello', 'alo']
        },
        options: {
          defaultLanguage: "en",
          renderToStaticMarkup: ReactDOMServer.renderToStaticMarkup
        }
      }}>
        <LocalizedApp />
      </LocalizeProvider>
    );

// from client
ReactDOM.hydrate(
    <LocalizeProvider initialize={{
        languages: [
          { name: "English", code: "en" },
          { name: "French", code: "fr" }
        ],
        translation: {
          hello: ['hello', 'alo']
        },
        options: {
          defaultLanguage: "en",
          renderToStaticMarkup: ReactDOMServer.renderToStaticMarkup
        }
      }}>
        <LocalizedApp />
   </LocalizeProvider>
)
```
Instead of repeating the initialize payload on both the server, and client you could use a workflow that is well known for [Redux and SSR](https://redux.js.org/recipes/serverrendering) where the initialState is stored in a window object. That is really up to the user to decide. 

If using server side rendering this will be used in place of the `initialize` action that would usually be called from a component lifecycle method. If not using server side rendering this prop could also be used in place of the `initialize` action call, that is up to the user, and what use case works best for them.