### PR TITLE
Added hoist-non-react-statics to withLocalized HOC

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
   "dependencies": {
     "create-react-context": "^0.2.2",
     "flat": "^2.0.1",
+    "hoist-non-react-statics": "^3.0.1",
     "prop-types": "^15.6.1",
     "reselect": "^3.0.1"
   }

--- a/src/withLocalize.js
+++ b/src/withLocalize.js
@@ -1,16 +1,19 @@
 import React, { Component, type ComponentType } from 'react';
+import hoistNonReactStatic from 'hoist-non-react-statics';
 import { LocalizeContext, type LocalizeContextProps } from './LocalizeContext';
 
 export function withLocalize<Props: {}>(
   WrappedComponent: ComponentType<Props>
 ): ComponentType<$Diff<Props, { ...LocalizeContextProps }>> {
-  const LocalizedComponent = (props: Props) => {
-    return (
-      <LocalizeContext.Consumer>
-        {context => <WrappedComponent {...context} {...props} />}
-      </LocalizeContext.Consumer>
-    );
-  };
-
+  class LocalizedComponent extends Component {
+    render() {
+      return (
+        <LocalizeContext.Consumer>
+          {context => <WrappedComponent {...context} {...this.props} />}
+        </LocalizeContext.Consumer>
+      );
+    }
+  }
+  hoistNonReactStatic(LocalizedComponent, WrappedComponent);
   return LocalizedComponent;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2830,6 +2830,12 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+hoist-non-react-statics@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.0.1.tgz#fba3e7df0210eb9447757ca1a7cb607162f0a364"
+  dependencies:
+    react-is "^16.3.2"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -4980,6 +4986,10 @@ react-dom@^16.3.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-is@^16.3.2:
+  version "16.5.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.2.tgz#e2a7b7c3f5d48062eb769fcb123505eb928722e3"
 
 react-is@^16.4.0:
   version "16.4.0"


### PR DESCRIPTION
I wanted to use a static method in a react class component in SSR, but I noticed that the static functions aren't hoisted in **withLocalize** HOC.

This PR adds to **withLocalize** HOC automatic hoisting to non react statics using `hoist-non-react-statics` as per https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over