### PR TITLE
using React.Fragment for wrapping React translations

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -47,7 +47,7 @@ export const getLocalizedElement = (
   }
 
   // return as Element
-  return React.createElement('span', null, ...translatedValueOrArray);
+  return React.createElement(React.Fragment, null, ...translatedValueOrArray);
 };
 
 export const hasHtmlTags = (value: string): boolean => {

--- a/tests/Translate.test.js
+++ b/tests/Translate.test.js
@@ -110,7 +110,9 @@ describe('<Translate />', () => {
     const Comp = ({name}) => <strong>{name}</strong>;
     const Translate = getTranslateWithContext();
     const wrapper = mount(
-      <Translate id='placeholder' data={{ name: <Comp name='ReactJS' /> }} />
+      <div>
+        <Translate id='placeholder' data={{ name: <Comp name='ReactJS' /> }} />
+      </div>
     );
 
     expect(wrapper.find(Comp).length).toBe(1);

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -51,10 +51,13 @@ describe('locale utils', () => {
     it('should handle React in data', () => {
       const Comp = () => <div>ReactJS</div>
       const translation = 'Hello ${ comp } data';
-      const result = utils.getLocalizedElement({
-        translation,
-        data: { comp: <Comp /> }
-      });
+      const result = (
+          <div>
+            {utils.getLocalizedElement({
+              translation,
+              data: { comp: <Comp /> }
+            })}
+          </div>);
       expect(mount(result).text()).toContain('ReactJS');
     })
   });


### PR DESCRIPTION
Hi Ryan,

When I using React translation in react-native.
Following error occurred.

```
Invariant Violation: View config not found for name span
```

It should wrap translated components by React.Fragment