### PR TITLE
Ensured that store from props is initialized with initialize from props.

### DIFF
--- a/src/LocalizeProvider.js
+++ b/src/LocalizeProvider.js
@@ -70,7 +70,7 @@ export class LocalizeProvider extends Component<
 
   initExternalStore() {
     const { store, initialize } = this.props;
-    if (store && initialize !== undefined) {
+    if (store && initialize) {
       store.dispatch(initializeAC(initialize));
     }
   }

--- a/src/LocalizeProvider.js
+++ b/src/LocalizeProvider.js
@@ -7,6 +7,7 @@ import {
   getTranslationsForActiveLanguage,
   type LocalizeState,
   type Action,
+  initialize as initializeAC,
   INITIALIZE,
   InitializePayload
 } from './localize';
@@ -58,21 +59,30 @@ export class LocalizeProvider extends Component<
     };
   }
 
-  static getDerivedStateFromProps(nextProps: any, nextState: any) {
-    return null;
-  }
-
   componentDidMount() {
-    if (this.props.store) {
-      this.unsubscribeFromStore = storeDidChange(
-        this.props.store,
-        this.onStateDidChange.bind(this)
-      );
-    }
+    this.initExternalStore();
+    this.subscribeToExternalStore();
   }
 
   componentWillUnmount() {
     this.unsubscribeFromStore && this.unsubscribeFromStore();
+  }
+
+  initExternalStore() {
+    const { store, initialize } = this.props;
+    if (store && initialize !== undefined) {
+      store.dispatch(initializeAC(initialize));
+    }
+  }
+
+  subscribeToExternalStore() {
+    const { store } = this.props;
+    if (store) {
+      this.unsubscribeFromStore = storeDidChange(
+        store,
+        this.onStateDidChange.bind(this)
+      );
+    }
   }
 
   onStateDidChange(prevState: LocalizeProviderState) {

--- a/tests/LocalizeProvider.test.js
+++ b/tests/LocalizeProvider.test.js
@@ -1,23 +1,19 @@
 import React from 'react';
-import ReactDOMServer from "react-dom/server";
-import Enzyme, { shallow } from 'enzyme';
+import ReactDOMServer from 'react-dom/server';
+import Enzyme, { shallow, mount } from 'enzyme';
 import { createStore, combineReducers } from 'redux';
 import Adapter from 'enzyme-adapter-react-16';
-import { Map } from 'immutable'
+import { Map } from 'immutable';
 import { LocalizeProvider } from '../src/LocalizeProvider';
 import { localizeReducer } from '../src/localize';
-import { getTranslate, getLanguages, initialize, withLocalize, Translate } from '../src';
+import { getTranslate, getLanguages, withLocalize, Translate } from '../src';
 import { defaultTranslateOptions } from '../src/localize';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-
 describe('<LocalizeProvider />', () => {
   const initialState = {
-    languages: [
-      { code: 'en', active: true },
-      { code: 'fr', active: false }
-    ],
+    languages: [{ code: 'en', active: true }, { code: 'fr', active: false }],
     translations: {
       hello: ['Hello', 'Hello FR'],
       bye: ['Goodbye', 'Goodbye FR'],
@@ -28,14 +24,16 @@ describe('<LocalizeProvider />', () => {
   };
 
   const getMockStore = () => {
-    return createStore(combineReducers({ 
-      localize: localizeReducer
-    }));
+    return createStore(
+      combineReducers({
+        localize: localizeReducer
+      })
+    );
   };
   const getImmutableStore = () => {
-    const reducer = (s, a) => Map({localize: localizeReducer(s, a)});
-    return createStore(reducer, Map({localize: initialState}));
-  }
+    const reducer = (s, a) => Map({ localize: localizeReducer(s, a) });
+    return createStore(reducer, Map({ localize: initialState }));
+  };
 
   it('should set default values for localize state', () => {
     const wrapper = shallow(
@@ -61,19 +59,17 @@ describe('<LocalizeProvider />', () => {
       languages: getLanguages(initialState),
       defaultLanguage: 'en',
       activeLanguage: initialState.languages[0]
-    })
+    });
   });
 
   it('should not throw error when store prop when passed', () => {
     const store = getMockStore();
-    const wrapper = 
-
-    expect(() => {
+    const wrapper = expect(() => {
       shallow(
         <LocalizeProvider store={store}>
           <div>Hello</div>
         </LocalizeProvider>
-      )
+      );
     }).not.toThrow();
   });
 
@@ -81,10 +77,13 @@ describe('<LocalizeProvider />', () => {
     const store = getImmutableStore();
     expect(() => {
       shallow(
-        <LocalizeProvider store={store} getState={state => state.get('localize')}>
-        <div>Hello</div>
+        <LocalizeProvider
+          store={store}
+          getState={state => state.get('localize')}
+        >
+          <div>Hello</div>
         </LocalizeProvider>
-      )
+      );
     }).not.toThrow();
   });
 
@@ -95,14 +94,14 @@ describe('<LocalizeProvider />', () => {
 
         this.props.initialize({
           languages: [
-            { name: "English", code: "en" },
-            { name: "French", code: "fr" }
+            { name: 'English', code: 'en' },
+            { name: 'French', code: 'fr' }
           ],
           translation: {
             hello: ['hello', 'alo']
           },
           options: {
-            defaultLanguage: "en",
+            defaultLanguage: 'en',
             renderToStaticMarkup: ReactDOMServer.renderToStaticMarkup
           }
         });
@@ -120,23 +119,49 @@ describe('<LocalizeProvider />', () => {
     const LocalizedApp = withLocalize(App);
 
     const result = ReactDOMServer.renderToString(
-      <LocalizeProvider initialize={{
-        languages: [
-          { name: "English", code: "en" },
-          { name: "French", code: "fr" }
-        ],
-        translation: {
-          hello: ['hello', 'alo']
-        },
-        options: {
-          defaultLanguage: "en",
-          renderToStaticMarkup: ReactDOMServer.renderToStaticMarkup
-        }
-      }}>
+      <LocalizeProvider
+        initialize={{
+          languages: [
+            { name: 'English', code: 'en' },
+            { name: 'French', code: 'fr' }
+          ],
+          translation: {
+            hello: ['hello', 'alo']
+          },
+          options: {
+            defaultLanguage: 'en',
+            renderToStaticMarkup: ReactDOMServer.renderToStaticMarkup
+          }
+        }}
+      >
         <LocalizedApp />
       </LocalizeProvider>
     );
 
     expect(result).toEqual('<div>hello</div>');
+  });
+
+  it('should work when store and initialize are passed to Provider', () => {
+    const store = getMockStore();
+    const initializePayload = {
+      languages: [
+        { name: 'English', code: 'en' },
+        { name: 'French', code: 'fr' }
+      ],
+      translation: {
+        hello: ['hello', 'alo']
+      },
+      options: {
+        defaultLanguage: 'en',
+        renderToStaticMarkup: ReactDOMServer.renderToStaticMarkup
+      }
+    };
+    shallow(
+      <LocalizeProvider store={store} initialize={initializePayload}>
+        <div>Hello</div>
+      </LocalizeProvider>
+    );
+    const translation = store.getState().localize.translations;
+    expect(translation).toEqual(initializePayload.translation);
   });
 });

--- a/tests/LocalizeProvider.test.js
+++ b/tests/LocalizeProvider.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
-import Enzyme, { shallow, mount } from 'enzyme';
+import Enzyme, { shallow } from 'enzyme';
 import { createStore, combineReducers } from 'redux';
 import Adapter from 'enzyme-adapter-react-16';
 import { Map } from 'immutable';


### PR DESCRIPTION
This addresses the 'provider initialization failure' in #135 .

## Problem
When _both_ `store` and `initialize` are passed to `LocalizeProvider`, the store is not initialized with the passed payload.

If `initialize` is omitted, this problem does not occur because the `initialize()` function is called from userland (from the `withLocalize`-wrapped component). This explicitly dispatches the initialize action.

If `store` is omitted, this problem does not occur because there is already code to initialize the passed payload into `LocalizeProvider`'s state.

## Changes
I have added a method that initializes the passed `store` with the passed `initialize` payload (if both are present), and call it in `componentDidMount`. Since there are more things happening in `componentDidMount` as a result of this, I extracted the existing code (subscribe to store) to a separate method. I have also added a test.

I think some parts of this diff are caused by prettier not being run somewhere in the past. The new test is at the end of the test file.