### PR TITLE
updated typescript definition for localizeReducer function

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -178,7 +178,7 @@ export type Action = BaseAction<
 export type ActionLanguageCodes = Action & { languageCodes: string[] };
 
 export function localizeReducer(
-  state: LocalizeState,
+  state: LocalizeState | undefined,
   action: Action
 ): LocalizeState;
 


### PR DESCRIPTION
This PR is in reference to [Issue #69](https://github.com/ryandrewjohnson/react-localize-redux/issues/69) specifically [this comment](https://github.com/ryandrewjohnson/react-localize-redux/issues/69#issuecomment-448863314)

it expands the definition of the `localizeReducer` function to solve TS errors