### PR TITLE
Fixed Missing TranslationID message

### DIFF
--- a/src/localize.js
+++ b/src/localize.js
@@ -305,7 +305,7 @@ export const defaultTranslateOptions: InitializeOptionsRequired = {
   ignoreTranslateChildren: false,
   defaultLanguage: '',
   onMissingTranslation: ({ translationId, languageCode }) =>
-    'Missing translationId: ${ translationId } for language: ${ languageCode }'
+    `Missing translationId: ${translationId} for language: ${languageCode}`
 };
 
 const initialState: LocalizeState = {


### PR DESCRIPTION
It needs to be a template string to work
