### PR TITLE
Add use translate

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -208,6 +208,8 @@ export function getActiveLanguage(state: LocalizeState): Language;
 
 export function getTranslate(state: LocalizeState): TranslateFunction;
 
+export function useTranslate(): LocalizeContextProps;
+
 export function withLocalize<Props extends LocalizeContextProps>(
   WrappedComponent: ComponentType<Props>
 ): ComponentType<Pick<Props, Exclude<keyof Props, keyof LocalizeContextProps>>>;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 // @flow
 export { Translate } from './Translate';
+export { useTranslate } from './useTranslate';
 export { withLocalize } from './withLocalize';
 export { LocalizeProvider } from './LocalizeProvider';
 export { LocalizeContext } from './LocalizeContext';

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -84,6 +84,8 @@ declare export function getActiveLanguage(state: LocalizeState): Language;
 
 declare export function getTranslate(state: LocalizeState): TranslateFunction;
 
+declare export function useTranslate(): LocalizeContextProps;
+
 declare export function withLocalize<Props: {}>(
   WrappedComponent: ComponentType<Props>
 ): ComponentType<$Diff<Props, { ...LocalizeContextProps }>>;

--- a/src/useTranslate.js
+++ b/src/useTranslate.js
@@ -1,5 +1,5 @@
 // @flow
 import { useContext } from 'react';
-import { LocalizeContext, LocalizeContextProps } from './LocalizeContext';
+import { LocalizeContext } from './LocalizeContext';
 
 export const useTranslate = () => useContext(LocalizeContext);

--- a/src/useTranslate.js
+++ b/src/useTranslate.js
@@ -1,0 +1,5 @@
+// @flow
+import { useContext } from 'react';
+import { LocalizeContext, LocalizeContextProps } from './LocalizeContext';
+
+export const useTranslate = () => useContext(LocalizeContext);


### PR DESCRIPTION
I run the "flow" command, and it show some errors in demo and LocalizeProvider,
which I haven't touched!

Beside that, there is a lot of js files that uses typescript syntax,
so this branch seems to be a bad one for testing on...

But the code for useTranslate is like this.
(We use a version of useTranslate I wrote to our ts project on my primary work place,
 - it actually work in the current version of react-localize-redux)