### PR TITLE
Fix state changes on any action

### DIFF
--- a/src/localize.js
+++ b/src/localize.js
@@ -322,14 +322,22 @@ export const localizeReducer = (
   const languagesState = languages(state.languages, action);
   const languageCodes = languagesState.map(language => language.code);
 
-  return {
-    languages: languagesState,
-    translations: translations(state.translations, {
-      ...action,
-      languageCodes
-    }),
-    options: options(state.options, { ...action, languageCodes })
-  };
+  const translationsState = translations(state.translations, {
+    ...action,
+    languageCodes
+  });
+
+  const optionsState = options(state.options, { ...action, languageCodes });
+
+  return state.languages !== languagesState ||
+    state.translations !== translationsState ||
+    state.options !== optionsState
+    ? {
+        languages: languagesState,
+        translations: translationsState,
+        options: optionsState
+      }
+    : state;
 };
 
 /**

--- a/tests/localize.test.js
+++ b/tests/localize.test.js
@@ -531,6 +531,17 @@ describe('localize', () => {
     });
   });
 
+  describe('reducer: state', () => {
+    describe('UNHANDLED_ACTION', () => {
+      it('should not make the state change in any way', () => {
+        const action = { type: 'UNHANDLED_ACTION' };
+        const initialState = localizeReducer(undefined, action);
+        const result = initialState;
+        expect(result).toBe(localizeReducer(initialState, action));
+      });
+    });
+  });
+
   describe('getActiveLanguage', () => {
     it('should return the active language object', () => {
       const state = {


### PR DESCRIPTION
Fixed that the state changes on any action which is passed into the localizeReducer. 

The problem was that the state was recreated on every localizeReducer call. The reducers for each of the states properties work correctly and only touches the state, when an action is modifing part of the state.

I added a unit tests and ran flow and all other tests. Unfortunately I got errors on both right after checking out the current master.