### PR TITLE
Add missing type import that crashes Vite builds

### DIFF
--- a/src/LocalizeProvider.js
+++ b/src/LocalizeProvider.js
@@ -8,8 +8,7 @@ import {
   type LocalizeState,
   type Action,
   initialize as initializeAC,
-  INITIALIZE,
-  InitializePayload
+  INITIALIZE
 } from './localize';
 import {
   LocalizeContext,
@@ -20,6 +19,12 @@ import { storeDidChange } from './utils';
 
 type LocalizeProviderState = {
   localize: LocalizeState
+};
+
+type InitializePayload = {
+  languages: Array<string | NamedLanguage>,
+  translation?: Object,
+  options?: InitializeOptions
 };
 
 export type LocalizeProviderProps = {

--- a/src/LocalizeProvider.js
+++ b/src/LocalizeProvider.js
@@ -8,7 +8,8 @@ import {
   type LocalizeState,
   type Action,
   initialize as initializeAC,
-  INITIALIZE
+  INITIALIZE,
+  type InitializePayload
 } from './localize';
 import {
   LocalizeContext,
@@ -19,12 +20,6 @@ import { storeDidChange } from './utils';
 
 type LocalizeProviderState = {
   localize: LocalizeState
-};
-
-type InitializePayload = {
-  languages: Array<string | NamedLanguage>,
-  translation?: Object,
-  options?: InitializeOptions
 };
 
 export type LocalizeProviderProps = {


### PR DESCRIPTION
Add type-prefix to import. The bundler does not know to remove InitializePayload from the import, making builds fail for Vite (esbuild).

Fixes #223